### PR TITLE
Resolvido

### DIFF
--- a/0.Comments.md
+++ b/0.Comments.md
@@ -1,0 +1,48 @@
+# Sobre os bugs apresentados e suas correções
+
+## A solução apresentada não efetua o último movimento necessário
+
+A descrição deste bug é um pouco enganadora. O último disco no pino de origem não era movido e a torre era considerada como solucionada. Isso acontecia por causa de uma checagem em `Domain.TorreHanoi.TorreHanoi.Resolver(int numeroDiscosRestante, Pino origem, Pino intermediario, Pino destino)`:
+
+
+    if (numeroDiscosRestante <= 1)
+    {
+        return;
+    }
+
+Como `numeroDiscosRestante` corresponde diretamente ao numero de discos que deve ser movido do pino de origem para o pino de destino, a checagem ignorava o ultimo disco no pino de origem. A correção é bem simples:
+
+
+    if (numeroDiscosRestante <= 0)
+    {
+        return;
+    }
+
+
+## A API não retorna a imagem do estado atual de uma execução
+
+Neste caso, a descrição é bem literal. O erro se encontrava em `Application.TorreHanoi.Implementation.TorreHanoiApplicationService.ObterImagemProcessoPor(string id)`:
+
+    var torre = _domainService.ObterPor(new Guid());
+
+O parametro `id` não era passado para o metodo de serviço. Em vez disso um Guid vazio era passado. A correção novamente foi bem simples:
+
+    var torre = _domainService.ObterPor(new Guid(id));
+
+## A imagem gerada para visualização da torre não leva em consideração o tamanho dos discos utilizados.
+
+Este não era um dos bugs iniciais mas algo que notei enquanto testava a correção para o bug anterior. Quantidades de discos acima de 5 geram discos largos o bastante para sobrepor discos em outros pinos. Isso acontece porque o espaçamento entre os pinos é constante enquanto a largura dos discos é definida por
+
+    var larguraDoDisco = disco.Id * _larguraPadrao;
+
+Como este não é um dos bugs originais (e pode estar fora de escopo para o projeto), ele não foi corrigido. Soluções possiveis incluem: 
+
+- Escalar a distancia entre pinos (e portanto o tamanho da imagem) com o numero de discos.
+- Utilizar um modelo aditivo para a largura adicional (`var larguraDoDisco = disco.Id * _ajuste + _larguraPadrao;` onde `_ajuste` é a difença em pixels na largura de dois discos sequenciais). Esta solução permite manter o tamanho da imagem para uma quantidade maior de discos, mas exibira o mesmo problema da solução atual eventualmente.
+- Escalar o tamanho das representações com o numero de discos. Esta solução permite torres de tamanho arbitrário mas tem legibilidade reduzida para torres maiores.
+
+
+# Sobre os testes unitários.
+
+Além dos testes para os bugs mencionados, um terceiro teste falha: `Tests.TorreHanoi.Domain.TorreHanoiUnit.Construtor_Deve_Retornar_Sucesso()`. Este teste também foi implementado.
+

--- a/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
+++ b/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
@@ -103,7 +103,9 @@ namespace Application.TorreHanoi.Implementation
             }
             try
             {
-                var torre = _domainService.ObterPor(new Guid());
+                // Era _domainService.ObterPor(new Guid()), sempre procurando a torre 00000000-0000-0000-0000-000000000000.
+                // Considerando que id já foi validado acima, usando o construtor diretamente.
+                var torre = _domainService.ObterPor(new Guid(id));
 
                 _designerService.Inicializar(_adpterTorreHanoi.DomainParaDesignerDto(torre));
 

--- a/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
+++ b/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
@@ -57,7 +57,8 @@ namespace Domain.TorreHanoi
 
         private void Resolver(int numeroDiscosRestante, Pino origem, Pino intermediario, Pino destino)
         {
-            if (numeroDiscosRestante <= 1)
+            //Era numeroDiscosRestante <= 1, ignorando o ultimo disco da torre de origem.
+            if (numeroDiscosRestante <= 0)
             {
                 return;
             }

--- a/5.Tests/Tests.TorreHanoi/Application/TorreHanoiApplicationServiceUnit.cs
+++ b/5.Tests/Tests.TorreHanoi/Application/TorreHanoiApplicationServiceUnit.cs
@@ -25,6 +25,7 @@ namespace Tests.TorreHanoi.Application
             mockLogger.Setup(s => s.Logar(It.IsAny<string>(), It.IsAny<TipoLog>()));
 
             var mockDesignerService = new Mock<IDesignerService>();
+            mockDesignerService.Setup(s => s.Desenhar()).Returns(() => new System.Drawing.Bitmap(1, 1));
 
             var mockTorreHanoiDomainService = new Mock<ITorreHanoiDomainService>();
             mockTorreHanoiDomainService.Setup(s => s.Criar(It.IsAny<int>())).Returns(Guid.NewGuid);
@@ -79,7 +80,15 @@ namespace Tests.TorreHanoi.Application
         [TestCategory(CategoriaTeste)]
         public void ObterImagemProcessoPor_Deve_Retornar_Imagem()
         {
-            Assert.Fail();
+            var responseObterImagemProcessoPor = _service.ObterImagemProcessoPor(Guid.NewGuid().ToString());
+
+
+            Assert.IsNotNull(responseObterImagemProcessoPor, "Resposta nula");
+            Assert.AreEqual(responseObterImagemProcessoPor.StatusCode, HttpStatusCode.OK, "Codigo de status inexperado");
+            Assert.IsNotNull(responseObterImagemProcessoPor.Imagem, "Imagem nula");
+            Assert.IsTrue(responseObterImagemProcessoPor.IsValid, "Resposta invalida");
+            Assert.IsTrue(responseObterImagemProcessoPor.MensagensDeErro.Count == 0, "Mensagens de erro retornadas");
+
         }
     }
 }

--- a/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
+++ b/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
@@ -18,19 +18,53 @@ namespace Tests.TorreHanoi.Domain
             _mockLogger = new Mock<ILogger>();
             _mockLogger.Setup(s => s.Logar(It.IsAny<string>(), It.IsAny<TipoLog>()));
         }
-
+        
         [TestMethod]
         [TestCategory(CategoriaTeste)]
         public void Construtor_Deve_Retornar_Sucesso()
         {
-            Assert.Fail();
+            // Esse teste já tinha sido implementado em Tests.TorreHanoi.Domain.PinoUnit.Construtor_Deve_Retornar_Sucesso()
+            // Talvez seja interessante testar o construtor de Domain.TorreHanoi.Pino individualmente.
+
+            var torre = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+
+            Assert.IsNotNull(torre);
+            Assert.IsNotNull(torre.Destino);
+            Assert.IsNotNull(torre.Origem);
+            Assert.IsNotNull(torre.Intermediario);
+            Assert.AreEqual(torre.Origem.Tipo, global::Domain.TorreHanoi.TipoPino.Origem);
+            Assert.AreEqual(torre.Destino.Tipo, global::Domain.TorreHanoi.TipoPino.Destino);
+            Assert.AreEqual(torre.Intermediario.Tipo, global::Domain.TorreHanoi.TipoPino.Intermediario);
+            Assert.AreEqual(torre.Intermediario.Discos.Count, 0);
+            Assert.AreEqual(torre.Destino.Discos.Count, 0);
+            Assert.AreEqual(torre.Origem.Discos.Count, 3);
+
+            Assert.AreNotEqual(torre.Id, new Guid());
+            Assert.AreNotEqual(torre.DataCriacao, new DateTime());
+            Assert.AreEqual(torre.Status, global::Domain.TorreHanoi.TipoStatus.Pendente);
+            Assert.IsNotNull(torre.PassoAPasso);
         }
 
         [TestMethod]
         [TestCategory(CategoriaTeste)]
         public void Processar_Deverar_Retornar_Sucesso()
         {
-            Assert.Fail();
+            var torre = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+
+            // Validando estado inicial.
+            Assert.AreEqual(torre.Origem.Discos.Count, 3, "Estado inicial inesperado. Pino Origem não contem o numero correto de discos.");
+            Assert.AreEqual(torre.Intermediario.Discos.Count, 0, "Estado inicial inesperado. Pino Intermediario contem discos.");
+            Assert.AreEqual(torre.Destino.Discos.Count, 0, "Estado inicial inesperado. Pino Destino contem discos.");
+
+            torre.Processar();
+
+            // Validando estado final.
+            Assert.AreEqual(torre.Status, global::Domain.TorreHanoi.TipoStatus.FinalizadoSucesso);
+            Assert.AreEqual(torre.Origem.Discos.Count, 0, "Estado final inesperado. Pino Origem contem discos.");
+            Assert.AreEqual(torre.Intermediario.Discos.Count, 0, "Estado final inesperado. Pino Intermediario contem discos.");
+            Assert.AreEqual(torre.Destino.Discos.Count, 3, "Estado final inesperado. Pino Destino não contem o numero correto de discos.");
+            Assert.AreNotEqual(torre.PassoAPasso.Count, 0, "Passo a passo não foi armazenado.");
+            
         }
     }
 }

--- a/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
+++ b/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
@@ -48,6 +48,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>

--- a/TorreHanoi.sln
+++ b/TorreHanoi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1.Presentation", "1.Presentation", "{812061B1-EA11-43C3-A050-5140664FF946}"
 EndProject
@@ -32,6 +32,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure.TorreHanoi.CacheManager", "4.Infrastructure\Infrastructure.TorreHanoi.CacheManager\Infrastructure.TorreHanoi.CacheManager.csproj", "{F3537F21-A3D4-4642-A560-2EA23EF9DD33}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure.TorreHanoi.Logger", "4.Infrastructure\Infrastructure.TorreHanoi.Logger\Infrastructure.TorreHanoi.Logger.csproj", "{415D27DD-10D7-49F6-A109-3556A6E3C290}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{36AD0C74-380D-4C6F-9DBF-B7303D3A1CC0}"
+	ProjectSection(SolutionItems) = preProject
+		0.Comments.md = 0.Comments.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -94,5 +99,8 @@ Global
 		{18D52A96-F541-443E-8595-ED2DB2DCCDFF} = {C686F904-FB17-4A9D-83CA-70788DC81D56}
 		{F3537F21-A3D4-4642-A560-2EA23EF9DD33} = {C686F904-FB17-4A9D-83CA-70788DC81D56}
 		{415D27DD-10D7-49F6-A109-3556A6E3C290} = {C686F904-FB17-4A9D-83CA-70788DC81D56}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {65666A00-3C06-4346-8885-928DC7DF9F6D}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
# Sobre os bugs apresentados e suas correções

## A solução apresentada não efetua o último movimento necessário

A descrição deste bug é um pouco enganadora. O último disco no pino de origem não era movido e a torre era considerada como solucionada. Isso acontecia por causa de uma checagem em `Domain.TorreHanoi.TorreHanoi.Resolver(int numeroDiscosRestante, Pino origem, Pino intermediario, Pino destino)`:


    if (numeroDiscosRestante <= 1)
    {
        return;
    }

Como `numeroDiscosRestante` corresponde diretamente ao numero de discos que deve ser movido do pino de origem para o pino de destino, a checagem ignorava o ultimo disco no pino de origem. A correção é bem simples:


    if (numeroDiscosRestante <= 0)
    {
        return;
    }


## A API não retorna a imagem do estado atual de uma execução

Neste caso, a descrição é bem literal. O erro se encontrava em `Application.TorreHanoi.Implementation.TorreHanoiApplicationService.ObterImagemProcessoPor(string id)`:

    var torre = _domainService.ObterPor(new Guid());

O parametro `id` não era passado para o metodo de serviço. Em vez disso um Guid vazio era passado. A correção novamente foi bem simples:

    var torre = _domainService.ObterPor(new Guid(id));

## A imagem gerada para visualização da torre não leva em consideração o tamanho dos discos utilizados.

Este não era um dos bugs iniciais mas algo que notei enquanto testava a correção para o bug anterior. Quantidades de discos acima de 5 geram discos largos o bastante para sobrepor discos em outros pinos. Isso acontece porque o espaçamento entre os pinos é constante enquanto a largura dos discos é definida por

    var larguraDoDisco = disco.Id * _larguraPadrao;

Como este não é um dos bugs originais (e pode estar fora de escopo para o projeto), ele não foi corrigido. Soluções possiveis incluem: 

- Escalar a distancia entre pinos (e portanto o tamanho da imagem) com o numero de discos.
- Utilizar um modelo aditivo para a largura adicional (`var larguraDoDisco = disco.Id * _ajuste + _larguraPadrao;` onde `_ajuste` é a difença em pixels na largura de dois discos sequenciais). Esta solução permite manter o tamanho da imagem para uma quantidade maior de discos, mas exibira o mesmo problema da solução atual eventualmente.
- Escalar o tamanho das representações com o numero de discos. Esta solução permite torres de tamanho arbitrário mas tem legibilidade reduzida para torres maiores.


# Sobre os testes unitários.

Além dos testes para os bugs mencionados, um terceiro teste falha: `Tests.TorreHanoi.Domain.TorreHanoiUnit.Construtor_Deve_Retornar_Sucesso()`. Este teste também foi implementado.

