### PR TITLE
Correções em API e testes

### DIFF
--- a/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
+++ b/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
@@ -103,7 +103,7 @@ namespace Application.TorreHanoi.Implementation
             }
             try
             {
-                var torre = _domainService.ObterPor(new Guid());
+                var torre = _domainService.ObterPor(new Guid(id));
 
                 _designerService.Inicializar(_adpterTorreHanoi.DomainParaDesignerDto(torre));
 

--- a/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
+++ b/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
@@ -57,7 +57,7 @@ namespace Domain.TorreHanoi
 
         private void Resolver(int numeroDiscosRestante, Pino origem, Pino intermediario, Pino destino)
         {
-            if (numeroDiscosRestante <= 1)
+            if (numeroDiscosRestante < 1)
             {
                 return;
             }

--- a/5.Tests/Tests.TorreHanoi/Application/TorreHanoiApplicationServiceUnit.cs
+++ b/5.Tests/Tests.TorreHanoi/Application/TorreHanoiApplicationServiceUnit.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using Application.TorreHanoi.Implementation;
+﻿using Application.TorreHanoi.Implementation;
 using Application.TorreHanoi.Interface;
 using Domain.TorreHanoi.Interface.Service;
 using Infrastructure.TorreHanoi.ImagemHelper;
 using Infrastructure.TorreHanoi.Log;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net;
 
 namespace Tests.TorreHanoi.Application
 {
@@ -25,6 +25,8 @@ namespace Tests.TorreHanoi.Application
             mockLogger.Setup(s => s.Logar(It.IsAny<string>(), It.IsAny<TipoLog>()));
 
             var mockDesignerService = new Mock<IDesignerService>();
+            mockDesignerService.Setup(s => s.Inicializar(It.IsAny<global::Infrastructure.TorreHanoi.ImagemHelper.Dto.TorreHanoiDto>()));
+            mockDesignerService.Setup(s => s.Desenhar()).Returns(new System.Drawing.Bitmap(300, 300));
 
             var mockTorreHanoiDomainService = new Mock<ITorreHanoiDomainService>();
             mockTorreHanoiDomainService.Setup(s => s.Criar(It.IsAny<int>())).Returns(Guid.NewGuid);
@@ -49,7 +51,7 @@ namespace Tests.TorreHanoi.Application
 
         [TestMethod]
         [TestCategory(CategoriaTeste)]
-        public void ObterProcessoPor_Deverar_Retornar_Sucesso()
+        public void ObterProcessoPor_Devera_Retornar_Sucesso()
         {
             var response = _service.ObterProcessoPor(Guid.NewGuid().ToString());
 
@@ -79,7 +81,13 @@ namespace Tests.TorreHanoi.Application
         [TestCategory(CategoriaTeste)]
         public void ObterImagemProcessoPor_Deve_Retornar_Imagem()
         {
-            Assert.Fail();
+            var response = _service.ObterImagemProcessoPor(Guid.NewGuid().ToString());
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(response.StatusCode, HttpStatusCode.OK);
+            Assert.IsNotNull(response.Imagem);
+            Assert.IsTrue(response.IsValid);
+            Assert.IsTrue(response.MensagensDeErro.Count == 0);
         }
     }
 }

--- a/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
+++ b/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
@@ -23,14 +23,34 @@ namespace Tests.TorreHanoi.Domain
         [TestCategory(CategoriaTeste)]
         public void Construtor_Deve_Retornar_Sucesso()
         {
-            Assert.Fail();
+            var torre = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+
+            Assert.IsNotNull(torre);
+            Assert.IsNotNull(torre.Id);
+            Assert.AreEqual(torre.Discos.Count, 3);
+            Assert.IsNotNull(torre.Destino);
+            Assert.IsNotNull(torre.Intermediario);
+            Assert.IsNotNull(torre.Origem);
+            Assert.IsNotNull(torre.DataCriacao);
+            Assert.AreEqual(torre.Status, global::Domain.TorreHanoi.TipoStatus.Pendente);
+            Assert.IsNotNull(torre.PassoAPasso);
+            Assert.AreEqual(torre.Origem.Tipo, global::Domain.TorreHanoi.TipoPino.Origem);
+            Assert.AreEqual(torre.Destino.Tipo, global::Domain.TorreHanoi.TipoPino.Destino);
+            Assert.AreEqual(torre.Intermediario.Tipo, global::Domain.TorreHanoi.TipoPino.Intermediario);
+            Assert.AreEqual(torre.Intermediario.Discos.Count, 0);
+            Assert.AreEqual(torre.Destino.Discos.Count, 0);
+            Assert.AreEqual(torre.Origem.Discos.Count, 3);
         }
 
         [TestMethod]
         [TestCategory(CategoriaTeste)]
         public void Processar_Deverar_Retornar_Sucesso()
         {
-            Assert.Fail();
+            var torre = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+            torre.Processar();
+
+            Assert.AreEqual(torre.Status, global::Domain.TorreHanoi.TipoStatus.FinalizadoSucesso);
+            Assert.IsNotNull(torre.DataFinalizacao);
         }
     }
 }

--- a/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
+++ b/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
@@ -48,6 +48,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>


### PR DESCRIPTION
O seguintes commits possuem correções na API na parte do processamento e geração de Desenho da torre de Hanoi.

**Processamento**
O Último passo não era realizado pois o método recursivo retornava quando o número de discos restantes fosse menor ou igual á 1.

**Desenho**
O Desenho não era gerado pois no método de inicialização do serviço de Design, uma Guid era instanciada com o construtor vazio, sem considerar o id do processamento selecionado.

**Testes**
Além da API, alguns testes foram corrigidos e especialmente para o caso do teste de retorno do Desenho, um mock do serviço de design precisou ser criado.


Para dúvidas ou maiores informações me mande um email em paulo.coe07@gmail.com 
