### PR TITLE
Corrigido a exibição da img, corrigido o bug da última movimentação e…

### DIFF
--- a/1.Presentation/Presentation.TorreHanoi/Controllers/TorreHanoiController.cs
+++ b/1.Presentation/Presentation.TorreHanoi/Controllers/TorreHanoiController.cs
@@ -1,4 +1,5 @@
 ﻿using Application.TorreHanoi.Interface;
+using System;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Net.Http;

--- a/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
+++ b/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
@@ -103,7 +103,8 @@ namespace Application.TorreHanoi.Implementation
             }
             try
             {
-                var torre = _domainService.ObterPor(new Guid());
+                var imgGuid = Guid.Parse(id);
+                var torre = _domainService.ObterPor(imgGuid);
 
                 _designerService.Inicializar(_adpterTorreHanoi.DomainParaDesignerDto(torre));
 

--- a/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
+++ b/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
@@ -57,7 +57,7 @@ namespace Domain.TorreHanoi
 
         private void Resolver(int numeroDiscosRestante, Pino origem, Pino intermediario, Pino destino)
         {
-            if (numeroDiscosRestante <= 1)
+            if (numeroDiscosRestante < 1)
             {
                 return;
             }

--- a/5.Tests/Tests.TorreHanoi/Application/TorreHanoiApplicationServiceUnit.cs
+++ b/5.Tests/Tests.TorreHanoi/Application/TorreHanoiApplicationServiceUnit.cs
@@ -8,6 +8,7 @@ using Infrastructure.TorreHanoi.ImagemHelper;
 using Infrastructure.TorreHanoi.Log;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System.Drawing;
 
 namespace Tests.TorreHanoi.Application
 {
@@ -25,7 +26,7 @@ namespace Tests.TorreHanoi.Application
             mockLogger.Setup(s => s.Logar(It.IsAny<string>(), It.IsAny<TipoLog>()));
 
             var mockDesignerService = new Mock<IDesignerService>();
-
+            mockDesignerService.Setup(s => s.Desenhar()).Returns(() => new Bitmap(10,10));
             var mockTorreHanoiDomainService = new Mock<ITorreHanoiDomainService>();
             mockTorreHanoiDomainService.Setup(s => s.Criar(It.IsAny<int>())).Returns(Guid.NewGuid);
             mockTorreHanoiDomainService.Setup(s => s.ObterPor(It.IsAny<Guid>())).Returns(() => new global::Domain.TorreHanoi.TorreHanoi(3, mockLogger.Object));
@@ -79,7 +80,15 @@ namespace Tests.TorreHanoi.Application
         [TestCategory(CategoriaTeste)]
         public void ObterImagemProcessoPor_Deve_Retornar_Imagem()
         {
-            Assert.Fail();
+            var process = _service.AdicionarNovoPorcesso(3);
+            
+            var response = _service.ObterImagemProcessoPor(process.IdProcesso.ToString());
+
+            Assert.IsNotNull(process);
+            Assert.AreEqual(response.StatusCode, HttpStatusCode.OK);
+            Assert.IsNotNull(response.Imagem);
+            Assert.IsTrue(response.IsValid);
+            Assert.IsTrue(response.MensagensDeErro.Count == 0);
         }
     }
 }

--- a/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
+++ b/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
@@ -2,6 +2,8 @@
 using Infrastructure.TorreHanoi.Log;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Domain.TorreHanoi;
+using System.Collections.Generic;
 
 namespace Tests.TorreHanoi.Domain
 {
@@ -23,14 +25,27 @@ namespace Tests.TorreHanoi.Domain
         [TestCategory(CategoriaTeste)]
         public void Construtor_Deve_Retornar_Sucesso()
         {
-            Assert.Fail();
+            var torre = new global::Domain.TorreHanoi.TorreHanoi(3,_mockLogger.Object);
+
+            Assert.IsNotNull(torre);
+            Assert.AreEqual(torre.Status, TipoStatus.Pendente);
+            Assert.AreNotEqual(torre.Id, new Guid());
+            Assert.IsNotNull(torre.Destino);
+            Assert.IsNotNull(torre.Intermediario);
+            Assert.IsNotNull(torre.Origem);
+            Assert.AreNotEqual(torre.DataCriacao, new DateTime());
+            Assert.AreEqual(torre.PassoAPasso.Count, 0);
         }
 
         [TestMethod]
         [TestCategory(CategoriaTeste)]
         public void Processar_Deverar_Retornar_Sucesso()
         {
-            Assert.Fail();
+            var torre = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+
+            torre.Processar();
+
+            Assert.AreEqual(torre.Status, TipoStatus.FinalizadoSucesso);
         }
     }
 }

--- a/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
+++ b/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
@@ -48,6 +48,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>


### PR DESCRIPTION
**#Problema ao efetuar último movimento necessário**
-- Corrigido em _Domain/Domain.TorreHanoi/TorreHanoi.cs_ (linha 60)

**#Problema da imagem que não retornava na API**
-- Corrigido em _Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs_ (linha 106)

**#Correção dos Testes Unitários**
-- Método **ObterImagemProcessoPor_Deve_Retornar_Imagem()** Implementado em _Tests/Tests.TorreHanoi/Application/TorreHanoiApplicationServiceUnit.cs_ (linha 81) 
-- Método **Construtor_Deve_Retornar_Sucesso()** implementado em _Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs_ (linha 26)
-- Método **Processar_Deverar_Retornar_Sucesso()** implementado em _Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs_ (linha 42)


