### PR TITLE
Teste C# para a Torre de Hanoi

### DIFF
--- a/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
+++ b/2.Application/Application.TorreHanoi/Implementation/TorreHanoiApplicationService.cs
@@ -103,7 +103,7 @@ namespace Application.TorreHanoi.Implementation
             }
             try
             {
-                var torre = _domainService.ObterPor(new Guid());
+                var torre = _domainService.ObterPor(new Guid(id));
 
                 _designerService.Inicializar(_adpterTorreHanoi.DomainParaDesignerDto(torre));
 

--- a/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
+++ b/3.Domain/Domain.TorreHanoi/TorreHanoi.cs
@@ -57,7 +57,7 @@ namespace Domain.TorreHanoi
 
         private void Resolver(int numeroDiscosRestante, Pino origem, Pino intermediario, Pino destino)
         {
-            if (numeroDiscosRestante <= 1)
+            if (numeroDiscosRestante <= 0)
             {
                 return;
             }

--- a/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
+++ b/5.Tests/Tests.TorreHanoi/Domain/TorreHanoiUnit.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using Infrastructure.TorreHanoi.Log;
+﻿using Infrastructure.TorreHanoi.Log;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System;
 
 namespace Tests.TorreHanoi.Domain
 {
@@ -21,16 +21,66 @@ namespace Tests.TorreHanoi.Domain
 
         [TestMethod]
         [TestCategory(CategoriaTeste)]
-        public void Construtor_Deve_Retornar_Sucesso()
+        public void Construtor_Deve_Retornar_StatusPendente()
         {
-            Assert.Fail();
+            var torreHanoi = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+
+            Assert.AreEqual(global::Domain.TorreHanoi.TipoStatus.Pendente, torreHanoi.Status);
+        }
+
+        [TestMethod]
+        [TestCategory(CategoriaTeste)]
+        public void Construtor_Deve_Gerar_Id_Para_A_TorreDeHanoi()
+        {
+            var torreHanoi = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+            Assert.AreNotEqual(new Guid(), torreHanoi.Id);
         }
 
         [TestMethod]
         [TestCategory(CategoriaTeste)]
         public void Processar_Deverar_Retornar_Sucesso()
         {
-            Assert.Fail();
+            var torreHanoi = new global::Domain.TorreHanoi.TorreHanoi(3, _mockLogger.Object);
+
+            torreHanoi.Processar();
+
+            Assert.AreEqual(global::Domain.TorreHanoi.TipoStatus.FinalizadoSucesso, torreHanoi.Status);
+        }
+
+        [TestMethod]
+        [TestCategory(CategoriaTeste)]
+        public void Processar_Deverar_Retornar_Torre_Com_Um_Disco_No_Destino()
+        {
+            var totalDeDiscos = 1;
+            var torreHanoi = new global::Domain.TorreHanoi.TorreHanoi(totalDeDiscos, _mockLogger.Object);
+
+            torreHanoi.Processar();
+
+            Assert.AreEqual(totalDeDiscos, torreHanoi.Destino.Discos.Count);
+        }
+
+        [TestMethod]
+        [TestCategory(CategoriaTeste)]
+        public void Processar_Deverar_Retornar_Torre_Com_Dois_Discos_No_Destino()
+        {
+            var totalDeDiscos = 2;
+            var torreHanoi = new global::Domain.TorreHanoi.TorreHanoi(totalDeDiscos, _mockLogger.Object);
+
+            torreHanoi.Processar();
+
+            Assert.AreEqual(totalDeDiscos, torreHanoi.Destino.Discos.Count);
+        }
+
+        [TestMethod]
+        [TestCategory(CategoriaTeste)]
+        public void Processar_Deverar_Retornar_Torre_Com_Tres_Discos_No_Destino()
+        {
+            var totalDeDiscos = 3;
+            var torreHanoi = new global::Domain.TorreHanoi.TorreHanoi(totalDeDiscos, _mockLogger.Object);
+
+            torreHanoi.Processar();
+
+            Assert.AreEqual(totalDeDiscos, torreHanoi.Destino.Discos.Count);
         }
     }
 }

--- a/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
+++ b/5.Tests/Tests.TorreHanoi/Tests.TorreHanoi.csproj
@@ -48,6 +48,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>


### PR DESCRIPTION
- [x] Aplicado testes para o construtor e método `Processar` da classe
`TorreHanoi`
- [x] Aplicado testes para a classe `TorreHanoiApplicationService` para
aumentar a cobertura do método `ObterImagem`
- [x] Método `ObterImagemPor` não estava utilizando o Id informado para obter
a Torre de Hanoi dentro de `TorreHanoiApplicationService`
- [x] Adicionar teste para validar que o método `Desenhar` esta sendo chamado dentro de `ObterImagemProcessoPor`
- [x] Adicionado testes para 1, 2 e 3 discos na Torre de Hanoi
- [x] Condição de parada no método `Resolver` estava impedindo a execução do
último passo
- [x] Adicionado testes para 1, 2 e 3 discos para a torre e ajustado bug na regra de domínio para o último passo